### PR TITLE
Unpin from our fork of go-snappystream

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	log "github.com/cihub/seelog"
-	"github.com/hailocab/go-snappystream"
+	"github.com/mreiferson/go-snappystream"
 )
 
 // IdentifyResponse represents the metadata


### PR DESCRIPTION
This undoes hailocab/go-nsq#11 :tada:
