### PR TITLE
Fix bounds err when removing lookupds.

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -382,6 +382,9 @@ exit:
 // keeping track of which one was last used
 func (r *Consumer) nextLookupdEndpoint() string {
 	r.mtx.RLock()
+	if r.lookupdQueryIndex >= len(r.lookupdHTTPAddrs) {
+		r.lookupdQueryIndex = 0
+	}
 	addr := r.lookupdHTTPAddrs[r.lookupdQueryIndex]
 	num := len(r.lookupdHTTPAddrs)
 	r.mtx.RUnlock()


### PR DESCRIPTION
When removing lookupds, `r.lookupdQueryIndex` may become greater than `len(r.lookupdHTTPAddrs)`.
This can cause a panic by index out of bounds error.

Stack trace from this happening in tst:

```
 panic: runtime error: index out of range
 
 goroutine 120 [running]:
 runtime.panic(0xa485a0, 0xe7ba3c)
 \t/usr/local/go/src/pkg/runtime/panic.c:279 +0xf5
 github.com/hailocab/go-nsq.(*Consumer).nextLookupdEndpoint(0xc208308280, 0x0, 0x0)
 \t/ebs/jenkins/jobs/hailocab-go-messaging-service-ccb9d543be50/workspace/.build-3j78M6Tj/src/github.com/hailocab/go-nsq/consumer.go:385 +0x537
 github.com/hailocab/go-nsq.(*Consumer).queryLookupd(0xc208308280)
 \t/ebs/jenkins/jobs/hailocab-go-messaging-service-ccb9d543be50/workspace/.build-3j78M6Tj/src/github.com/hailocab/go-nsq/consumer.go:414 +0x35
 github.com/hailocab/go-nsq.(*Consumer).lookupdLoop(0xc208308280)
 \t/ebs/jenkins/jobs/hailocab-go-messaging-service-ccb9d543be50/workspace/.build-3j78M6Tj/src/github.com/hailocab/go-nsq/consumer.go:369 +0x15f
 created by github.com/hailocab/go-nsq.(*Consumer).ConnectToNSQLookupd
 \t/ebs/jenkins/jobs/hailocab-go-messaging-service-ccb9d543be50/workspace/.build-3j78M6Tj/src/github.com/hailocab/go-nsq/consumer.go:314 +0x56a
```