### PR TITLE
Reduce noise

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -416,7 +416,7 @@ func (r *Consumer) nextLookupdEndpoint() string {
 func (r *Consumer) queryLookupd() {
 	endpoint := r.nextLookupdEndpoint()
 
-	clog.Infof("querying nsqlookupd %s", endpoint)
+	clog.Debugf("querying nsqlookupd %s", endpoint)
 
 	data, err := apiRequestNegotiateV1("GET", endpoint, nil)
 	if err != nil {


### PR DESCRIPTION
Change Infof => Debugf for querying lookupd message

All I can see in logs are nsq:
```
 2015-06-22 16:06:38 [INF] querying nsqlookupd http://X.X.X.X:4161/lookup?topic=BLAH (main.go 1)
 2015-06-22 16:06:37 [INF] querying nsqlookupd http://X.X.X.X:4161/lookup?topic=BLAH (main.go 1)
 2015-06-22 16:06:39 [INF] querying nsqlookupd http://X.X.X.X:4161/lookup?topic=BLAH (main.go 1)
 2015-06-22 16:06:39 [INF] querying nsqlookupd http://X.X.X.X:4161/lookup?topic=BLAH (main.go 1)
 2015-06-22 16:06:39 [INF] querying nsqlookupd http://X.X.X.X:4161/lookup?topic=BLAH (main.go 1)
```

mildly useful..
Looks like there has been a few attempts at this, some of them with the correct logging level for this message. 
https://github.com/bitly/go-nsq/compare/master...hailocab:domdebug
https://github.com/bitly/go-nsq/compare/master...hailocab:shush
https://github.com/bitly/go-nsq/compare/master...hailocab:backup